### PR TITLE
Add basic HotChocolate GraphQL POC

### DIFF
--- a/GraphQLDemo/Book.cs
+++ b/GraphQLDemo/Book.cs
@@ -1,0 +1,3 @@
+namespace GraphQLDemo;
+
+public record Book(string Id, string Name, string Author);

--- a/GraphQLDemo/BookRepository.cs
+++ b/GraphQLDemo/BookRepository.cs
@@ -1,0 +1,22 @@
+using System.Collections.Concurrent;
+
+namespace GraphQLDemo;
+
+public class BookRepository
+{
+    private readonly ConcurrentDictionary<string, Book> _books = new();
+
+    public IEnumerable<Book> GetAll() => _books.Values;
+
+    public Book? GetById(string id)
+    {
+        _books.TryGetValue(id, out var book);
+        return book;
+    }
+
+    public Book Add(Book book)
+    {
+        _books[book.Id] = book;
+        return book;
+    }
+}

--- a/GraphQLDemo/GraphQLDemo.csproj
+++ b/GraphQLDemo/GraphQLDemo.csproj
@@ -1,13 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
+    <PackageReference Include="HotChocolate.AspNetCore" Version="15.0.0-rc.3" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.4" />
   </ItemGroup>
 
 </Project>

--- a/GraphQLDemo/Mutation.cs
+++ b/GraphQLDemo/Mutation.cs
@@ -1,0 +1,10 @@
+namespace GraphQLDemo;
+
+public class Mutation
+{
+    public Book AddBook(string id, string name, string author, [Service] BookRepository repository)
+    {
+        var book = new Book(id, name, author);
+        return repository.Add(book);
+    }
+}

--- a/GraphQLDemo/Program.cs
+++ b/GraphQLDemo/Program.cs
@@ -1,23 +1,28 @@
+using GraphQLDemo;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 
 builder.Services.AddControllers();
-// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
-builder.Services.AddOpenApi();
+
+// GraphQL services
+builder.Services.AddSingleton<BookRepository>();
+builder.Services
+    .AddGraphQLServer()
+    .AddQueryType<Query>()
+    .AddMutationType<Mutation>();
 
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
-if (app.Environment.IsDevelopment())
-{
-    app.MapOpenApi();
-}
+
 
 app.UseHttpsRedirection();
 
 app.UseAuthorization();
 
 app.MapControllers();
+app.MapGraphQL();
 
 app.Run();

--- a/GraphQLDemo/Query.cs
+++ b/GraphQLDemo/Query.cs
@@ -1,0 +1,8 @@
+namespace GraphQLDemo;
+
+public class Query
+{
+    public IEnumerable<Book> GetBooks([Service] BookRepository repository) => repository.GetAll();
+
+    public Book? GetBook(string id, [Service] BookRepository repository) => repository.GetById(id);
+}


### PR DESCRIPTION
## Summary
- implement an in-memory `BookRepository`
- add `Book` entity along with `Query` and `Mutation` types
- configure HotChocolate v15 GraphQL server
- target .NET 8.0

## Testing
- `dotnet build ../GraphQLDemo.sln`

------
https://chatgpt.com/codex/tasks/task_e_6874e30fac6c8325b300d7ee5430f121