### PR TITLE
Add Author API project with unique ports

### DIFF
--- a/AuthorDemo/Author.cs
+++ b/AuthorDemo/Author.cs
@@ -1,0 +1,3 @@
+namespace AuthorDemo;
+
+public record Author(string Id, string Name, string Country);

--- a/AuthorDemo/AuthorDemo.csproj
+++ b/AuthorDemo/AuthorDemo.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="HotChocolate.AspNetCore" Version="15.0.0-rc.3" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.4" />
+  </ItemGroup>
+
+</Project>

--- a/AuthorDemo/AuthorDemo.http
+++ b/AuthorDemo/AuthorDemo.http
@@ -1,0 +1,6 @@
+@AuthorDemo_HostAddress = http://localhost:5284
+
+GET {{AuthorDemo_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/AuthorDemo/AuthorRepository.cs
+++ b/AuthorDemo/AuthorRepository.cs
@@ -1,0 +1,22 @@
+using System.Collections.Concurrent;
+
+namespace AuthorDemo;
+
+public class AuthorRepository
+{
+    private readonly ConcurrentDictionary<string, Author> _authors = new();
+
+    public IEnumerable<Author> GetAll() => _authors.Values;
+
+    public Author? GetById(string id)
+    {
+        _authors.TryGetValue(id, out var author);
+        return author;
+    }
+
+    public Author Add(Author author)
+    {
+        _authors[author.Id] = author;
+        return author;
+    }
+}

--- a/AuthorDemo/Controllers/WeatherForecastController.cs
+++ b/AuthorDemo/Controllers/WeatherForecastController.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace AuthorDemo.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class WeatherForecastController : ControllerBase
+{
+    private static readonly string[] Summaries = new[]
+    {
+        "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+    };
+
+    private readonly ILogger<WeatherForecastController> _logger;
+
+    public WeatherForecastController(ILogger<WeatherForecastController> logger)
+    {
+        _logger = logger;
+    }
+
+    [HttpGet(Name = "GetWeatherForecast")]
+    public IEnumerable<WeatherForecast> Get()
+    {
+        return Enumerable.Range(1, 5).Select(index => new WeatherForecast
+        {
+            Date = DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
+            TemperatureC = Random.Shared.Next(-20, 55),
+            Summary = Summaries[Random.Shared.Next(Summaries.Length)]
+        })
+        .ToArray();
+    }
+}

--- a/AuthorDemo/Mutation.cs
+++ b/AuthorDemo/Mutation.cs
@@ -1,0 +1,10 @@
+namespace AuthorDemo;
+
+public class Mutation
+{
+    public Author AddAuthor(string id, string name, string country, [Service] AuthorRepository repository)
+    {
+        var author = new Author(id, name, country);
+        return repository.Add(author);
+    }
+}

--- a/AuthorDemo/Program.cs
+++ b/AuthorDemo/Program.cs
@@ -1,0 +1,28 @@
+using AuthorDemo;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+
+builder.Services.AddControllers();
+
+// GraphQL services
+builder.Services.AddSingleton<AuthorRepository>();
+builder.Services
+    .AddGraphQLServer()
+    .AddQueryType<Query>()
+    .AddMutationType<Mutation>();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+
+
+app.UseHttpsRedirection();
+
+app.UseAuthorization();
+
+app.MapControllers();
+app.MapGraphQL();
+
+app.Run();

--- a/AuthorDemo/Properties/launchSettings.json
+++ b/AuthorDemo/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5284",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "https://localhost:7294;http://localhost:5284",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/AuthorDemo/Query.cs
+++ b/AuthorDemo/Query.cs
@@ -1,0 +1,8 @@
+namespace AuthorDemo;
+
+public class Query
+{
+    public IEnumerable<Author> GetAuthors([Service] AuthorRepository repository) => repository.GetAll();
+
+    public Author? GetAuthor(string id, [Service] AuthorRepository repository) => repository.GetById(id);
+}

--- a/AuthorDemo/WeatherForecast.cs
+++ b/AuthorDemo/WeatherForecast.cs
@@ -1,0 +1,13 @@
+namespace AuthorDemo
+{
+    public class WeatherForecast
+    {
+        public DateOnly Date { get; set; }
+
+        public int TemperatureC { get; set; } 
+
+        public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+
+        public string? Summary { get; set; }
+    }
+}

--- a/AuthorDemo/appsettings.Development.json
+++ b/AuthorDemo/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/AuthorDemo/appsettings.json
+++ b/AuthorDemo/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/GraphQLDemo.sln
+++ b/GraphQLDemo.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.13.35818.85 d17.13
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GraphQLDemo", "GraphQLDemo\GraphQLDemo.csproj", "{776421D5-7C6A-4477-A14D-112ED6844519}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AuthorDemo", "AuthorDemo\AuthorDemo.csproj", "{D49D5DED-4C17-407D-81ED-65A1AFE7A605}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{776421D5-7C6A-4477-A14D-112ED6844519}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{776421D5-7C6A-4477-A14D-112ED6844519}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{776421D5-7C6A-4477-A14D-112ED6844519}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D49D5DED-4C17-407D-81ED-65A1AFE7A605}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D49D5DED-4C17-407D-81ED-65A1AFE7A605}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D49D5DED-4C17-407D-81ED-65A1AFE7A605}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D49D5DED-4C17-407D-81ED-65A1AFE7A605}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- duplicate the book GraphQL service as `AuthorDemo`
- implement author record with id, name and country
- configure launch settings to run on ports 5284/7294
- include new project in solution so book and author APIs can run side by side

## Testing
- `dotnet build GraphQLDemo.sln`

------
https://chatgpt.com/codex/tasks/task_e_6874e599f5ec8325b444f9482d4f28f6