### PR TITLE
Add dynamic schema handling to AuthorDemo

### DIFF
--- a/AuthorDemo/AuthorDemo.csproj
+++ b/AuthorDemo/AuthorDemo.csproj
@@ -12,6 +12,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="author-types.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
     <Folder Include="Controllers\" />
   </ItemGroup>
 

--- a/AuthorDemo/JsonTypeModule.cs
+++ b/AuthorDemo/JsonTypeModule.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using HotChocolate.Execution.Configuration;
+using HotChocolate.Types;
+using HotChocolate.Types.Descriptors.Definitions;
+
+namespace AuthorDemo;
+
+public class JsonTypeModule : ITypeModule
+{
+    private readonly string _file;
+
+    public JsonTypeModule(string file)
+    {
+        _file = file;
+    }
+
+    public event EventHandler<EventArgs>? TypesChanged;
+
+    public async ValueTask<IReadOnlyCollection<ITypeSystemMember>> CreateTypesAsync(
+        IDescriptorContext context,
+        CancellationToken cancellationToken)
+    {
+        var types = new List<ITypeSystemMember>();
+
+        await using var file = File.OpenRead(_file);
+        using var json = await JsonDocument.ParseAsync(file, cancellationToken: cancellationToken);
+
+        foreach (var type in json.RootElement.EnumerateArray())
+        {
+            var typeDefinition = new ObjectTypeDefinition(type.GetProperty("name").GetString()!);
+
+            foreach (var field in type.GetProperty("fields").EnumerateArray())
+            {
+                typeDefinition.Fields.Add(
+                    new ObjectFieldDefinition(
+                        field.GetString()!,
+                        type: TypeReference.Parse("String!"),
+                        pureResolver: ctx => "foo"));
+            }
+
+            types.Add(
+                type.GetProperty("extension").GetBoolean()
+                    ? ObjectTypeExtension.CreateUnsafe(typeDefinition)
+                    : ObjectType.CreateUnsafe(typeDefinition));
+        }
+
+        return types;
+    }
+}

--- a/AuthorDemo/Program.cs
+++ b/AuthorDemo/Program.cs
@@ -1,4 +1,5 @@
 using AuthorDemo;
+using System.IO;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -11,7 +12,8 @@ builder.Services.AddSingleton<AuthorRepository>();
 builder.Services
     .AddGraphQLServer()
     .AddQueryType<Query>()
-    .AddMutationType<Mutation>();
+    .AddMutationType<Mutation>()
+    .AddTypeModule(new JsonTypeModule(Path.Combine(builder.Environment.ContentRootPath, "author-types.json")));
 
 var app = builder.Build();
 

--- a/AuthorDemo/author-types.json
+++ b/AuthorDemo/author-types.json
@@ -1,0 +1,7 @@
+[
+  {
+    "name": "AuthorInfo",
+    "fields": ["nickname", "bio"],
+    "extension": false
+  }
+]


### PR DESCRIPTION
## Summary
- add a `JsonTypeModule` that constructs types from a JSON definition
- include `author-types.json` with dynamic type declarations
- register the type module in `Program.cs`
- copy the JSON file to the build output

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874ebe994108325939f8f1e4839e5f7