### PR TITLE
Expose dynamic author schema

### DIFF
--- a/AuthorDemo/author-types.json
+++ b/AuthorDemo/author-types.json
@@ -1,7 +1,17 @@
 [
   {
     "name": "AuthorInfo",
-    "fields": ["nickname", "bio"],
+    "fields": [
+      { "name": "nickname", "type": "String" },
+      { "name": "bio", "type": "String" }
+    ],
     "extension": false
+  },
+  {
+    "name": "Query",
+    "fields": [
+      { "name": "authorInfo", "type": "AuthorInfo" }
+    ],
+    "extension": true
   }
 ]


### PR DESCRIPTION
## Summary
- define a dynamic AuthorInfo type and extend Query with a new `authorInfo` field
- parse field types in `JsonTypeModule` so extensions can specify return types

## Testing
- `dotnet build GraphQLDemo.sln`

------
https://chatgpt.com/codex/tasks/task_e_6874ef7deb3883258cdca3e4d90be1ef